### PR TITLE
Improve X-Forwarded headers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,7 @@ Key | Option | Default | Values | Description
 [parent.tls] | certificatekey | "" | "/path/to/file" | file containing your ssl key
 [parent.tls] | certificatefile | "" | "/path/to/file" | file containing your ssl certificate file
 [parent.tls] | insecureskipverify | false | true/false | to to true to ignore insecure certificates, usable for self-signed certificates
+[parent.tls] | clientauth | NoClientCert | string | server' policy for client authentication, see https://golang.org/pkg/crypto/tls/#ClientAuthType for details
 
 ### TLS Min/Max version
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -300,6 +300,46 @@ header_value = "###CLIENT_IP###"
 ```
 This will add the X-Forwarded-For header to all requests towards the backend server, with the IP of the client
 
+## X-Forwarded-Proto header
+To pass the X-Forwarded-Proto header you need to add a inbound ACL
+```
+[[loadbalancer.pools.INTERNAL_VIP_LB.outboundacls]]
+action = "add"
+header_key = "X-Forwarded-Proto"
+header_value = "###REQ_PROTO###"
+```
+This will add the X-Forwarded-Proto header to all requests towards the backend server, with the value 'http' or 'https'
+
+## X-Forwarded-Host header
+To pass the X-Forwarded-Host header you need to add a inbound ACL
+```
+[[loadbalancer.pools.INTERNAL_VIP_LB.outboundacls]]
+action = "add"
+header_key = "X-Forwarded-Host"
+header_value = "###REQ_HOST###"
+```
+This will add the X-Forwarded-Host header to all requests towards the backend server, with the host value from the incoming request without port number
+
+## X-Forwarded-Port header
+To pass the X-Forwarded-Port header you need to add a inbound ACL
+```
+[[loadbalancer.pools.INTERNAL_VIP_LB.outboundacls]]
+action = "add"
+header_key = "X-Forwarded-Port"
+header_value = "###LB_PORT###"
+```
+This will add the X-Forwarded-Port header to all requests towards the backend server, with the port that received the incoming request
+
+## X-Forwarded-Client-Cert header
+To pass the X-Forwarded-Cert header you need to add a inbound ACL
+```
+[[loadbalancer.pools.INTERNAL_VIP_LB.outboundacls]]
+action = "add"
+header_key = "X-Forwarded-Cert"
+header_value = "###CLIENT_CERT###"
+```
+This will add the X-Forwarded-Cert header to all requests towards the backend server, with the base64 PEM encoded client certificate when connection is mTLS
+
 ## Balancing Kerberos tickets
 To forward Kerberos requests you need to create a new TCP VIP, and ensure that the DNS name of this VIP contains the same hostname as the requests its serves.
 so if you have a vip with ip: 1.2.3.4 listening on TCP port 88 and forwarding them to your domain server (your.domain.com) listening on 3.3.3.3

--- a/internal/core/proxy.go
+++ b/internal/core/proxy.go
@@ -102,13 +102,14 @@ func (manager *Manager) InitializeProxies() {
 				existingProxy.OCSPStapling != pool.Listener.OCSPStapling ||
 				!reflect.DeepEqual(existingTLS.CipherSuites, newTLS.CipherSuites) ||
 				!reflect.DeepEqual(existingTLS.CurvePreferences, newTLS.CurvePreferences) ||
-				!reflect.DeepEqual(existingTLS.Certificates, newTLS.Certificates)
+				!reflect.DeepEqual(existingTLS.Certificates, newTLS.Certificates) ||
+				existingTLS.ClientAuth != newTLS.ClientAuth
 
 			// Has listener changed?
 			if listenerChanged {
 				// Interface changes, we need to restart the proxy, lets stop it
 				certchange := !reflect.DeepEqual(existingTLS.Certificates, newTLS.Certificates)
-				log.WithField("pool", poolname).Debugf("listener changed - mode:%t ip:%t port:%t, maxcon:%t readtimeout:%t writetimeout:%t ocsp:%t cert:%t cypher:%t curve:%t",
+				log.WithField("pool", poolname).Debugf("listener changed - mode:%t ip:%t port:%t, maxcon:%t readtimeout:%t writetimeout:%t ocsp:%t cert:%t cypher:%t curve:%t clientauth:%t",
 					existingProxy.ListenerMode != pool.Listener.Mode,
 					existingProxy.IP != pool.Listener.IP,
 					existingProxy.Port != pool.Listener.Port,
@@ -118,7 +119,8 @@ func (manager *Manager) InitializeProxies() {
 					existingProxy.OCSPStapling != pool.Listener.OCSPStapling,
 					certchange,
 					!reflect.DeepEqual(existingTLS.CipherSuites, newTLS.CipherSuites),
-					!reflect.DeepEqual(existingTLS.CurvePreferences, newTLS.CurvePreferences))
+					!reflect.DeepEqual(existingTLS.CurvePreferences, newTLS.CurvePreferences),
+					existingTLS.ClientAuth != newTLS.ClientAuth)
 				log.WithField("pool", poolname).Info("Restarting existing proxy for new listener settings")
 				existingProxy.Stop()
 				existingProxy.SetListener(pool.Listener.Mode, pool.Listener.IP, pool.Listener.Port, pool.Listener.MaxConnections, newTLS, pool.Listener.ReadTimeout, pool.Listener.WriteTimeout, pool.Listener.HTTPProto, pool.Listener.OCSPStapling)

--- a/pkg/proxy/proxy_http.go
+++ b/pkg/proxy/proxy_http.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -30,6 +32,8 @@ type customTransport struct {
 	*http.Transport
 	LocalAddr net.Addr
 }
+
+var variableRegex = regexp.MustCompile("###([A-Z_a-z]+)###")
 
 func customStatusPage(statusCode int, statusMessage string, req *http.Request) *http.Response {
 	var body []byte
@@ -129,66 +133,28 @@ func (t *customTransport) RoundTrip(req *http.Request) (res *http.Response, err 
 func processACLVariables(acl []ACL, l *Listener, backendnode BackendNode, req *http.Request) []ACL {
 	log := logging.For("proxy/aclvariables").WithField("pool", l.Name).WithField("localip", l.IP).WithField("localport", l.Port).WithField("mode", l.ListenerMode)
 
-	reg, err := regexp.Compile("###([A-Z_a-z]+)###")
-	if err != nil {
-		log.WithField("error", err).Warn("Unable to compile regex")
-		return acl
+	fn := func(m string) string {
+		name := variableRegex.FindStringSubmatch(m)[1]
+		value, err := getVariableValue(name, l, &backendnode, req)
+		if err != nil {
+			log.WithField("variable", name).WithField("error", err).Warn("Unable to get variable value")
+			return name
+		}
+		return value
 	}
 
 	var newACL []ACL
+
 	for _, acl := range acl {
 		// regex conversion
-		fn := func(m string) string {
-			p := reg.FindStringSubmatch(m)
-			switch p[1] {
-			case "NODE_ID":
-				return backendnode.UUID
-
-			case "NODE_IP":
-				return backendnode.IP
-
-			case "LB_IP":
-				return l.IP
-
-			case "REQ_URL":
-				return req.Host + req.URL.Path
-
-			case "REQ_QUERY":
-				return req.URL.RawQuery
-
-			case "REQ_PATH":
-				return req.URL.Path
-
-			case "REQ_HOST":
-				val := strings.Split(req.Host, ":")
-				return val[0]
-
-			case "REQ_IP":
-				val := strings.Split(req.Host, ":")
-				return val[1]
-
-			case "CLIENT_IP":
-				val := strings.Split(req.RemoteAddr, ":")
-				return val[0]
-
-			case "UUID":
-				id, uerr := uuid.NewV4() // used for sticky cookies
-				if uerr == nil {
-					return id.String()
-				}
-				return ""
-			}
-			// return same if no correct match
-			return p[1]
-		}
 		// header value
 		if acl.HeaderValue != "" {
-			newdata := reg.ReplaceAllStringFunc(acl.HeaderValue, fn)
+			newdata := variableRegex.ReplaceAllStringFunc(acl.HeaderValue, fn)
 			acl.HeaderValue = newdata
 		}
 		// cookie value
 		if acl.CookieValue != "" {
-			newdata := reg.ReplaceAllStringFunc(acl.CookieValue, fn)
+			newdata := variableRegex.ReplaceAllStringFunc(acl.CookieValue, fn)
 			acl.CookieValue = newdata
 		}
 		// append new line to acl
@@ -196,6 +162,82 @@ func processACLVariables(acl []ACL, l *Listener, backendnode BackendNode, req *h
 	}
 
 	return newACL
+}
+
+func getVariableValue(name string, l *Listener, backendnode *BackendNode, req *http.Request) (string, error) {
+	switch name {
+	case "NODE_ID":
+		return backendnode.UUID, nil
+
+	case "NODE_IP":
+		return backendnode.IP, nil
+
+	case "LB_IP":
+		return l.IP, nil
+
+	case "LB_PORT":
+		return strconv.Itoa(l.Port), nil
+
+	case "REQ_URL":
+		return req.Host + req.URL.Path, nil
+
+	case "REQ_QUERY":
+		return req.URL.RawQuery, nil
+
+	case "REQ_PATH":
+		return req.URL.Path, nil
+
+	case "REQ_HOST":
+		val := strings.Split(req.Host, ":")
+		return val[0], nil
+
+	case "REQ_IP":
+		val := strings.Split(req.Host, ":")
+		return val[0], nil
+
+	case "REQ_PROTO":
+		if req.TLS != nil {
+			return "https", nil
+		}
+		return "http", nil
+
+	case "CLIENT_IP":
+		val := strings.Split(req.RemoteAddr, ":")
+		return val[0], nil
+
+	case "CLIENT_CERT":
+		return getClientCertPEM(req)
+
+	case "UUID":
+		id, uerr := uuid.NewV4() // used for sticky cookies
+		if uerr == nil {
+			return id.String(), nil
+		}
+		return "", uerr
+	}
+
+	// return same if no correct match
+	return "", fmt.Errorf("Unknown variable: %v", name)
+}
+
+func getClientCertPEM(req *http.Request) (string, error) {
+	if req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {
+		cert := req.TLS.PeerCertificates[0]
+		block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
+		certPEM := pem.EncodeToMemory(&block)
+		if certPEM == nil {
+			return "", errors.New("Cannot extract certificate content")
+		}
+
+		replacer := strings.NewReplacer("-----BEGIN CERTIFICATE-----", "",
+			"-----END CERTIFICATE-----", "",
+			"\n", "")
+
+		cleanPEM := replacer.Replace(string(certPEM))
+
+		return cleanPEM, nil
+	}
+	return "", nil
 }
 
 func addClientSessionID(req *http.Request, res *http.Response, id string) {

--- a/pkg/proxy/proxy_http_test.go
+++ b/pkg/proxy/proxy_http_test.go
@@ -60,6 +60,7 @@ func TestGetVariableValue(t *testing.T) {
 	httpRequest := createHTTPRequest()
 	httpsRequest := createHTTPSRequest()
 	httpsRequestWithCertificate := createHTTPSRequestWithClientCertificate()
+	httpsRequestWithMultipleCertificates := createHTTPSRequestWithMultipleClientCertificates()
 
 	var testData = []struct {
 		name          string
@@ -169,6 +170,12 @@ func TestGetVariableValue(t *testing.T) {
 			expectedError: nil,
 			request:       httpsRequestWithCertificate,
 		},
+		{
+			name:          "CLIENT_CERT",
+			expectedValue: certPEM + "," + certPEM,
+			expectedError: nil,
+			request:       httpsRequestWithMultipleCertificates,
+		},
 	}
 
 	for index, data := range testData {
@@ -208,6 +215,15 @@ func createHTTPSRequest() *http.Request {
 func createHTTPSRequestWithClientCertificate() *http.Request {
 	req := createHTTPSRequest()
 	req.TLS.PeerCertificates = []*x509.Certificate{
+		mustParsePEMCertificate(certPEM),
+	}
+	return req
+}
+
+func createHTTPSRequestWithMultipleClientCertificates() *http.Request {
+	req := createHTTPSRequest()
+	req.TLS.PeerCertificates = []*x509.Certificate{
+		mustParsePEMCertificate(certPEM),
 		mustParsePEMCertificate(certPEM),
 	}
 	return req

--- a/pkg/proxy/proxy_http_test.go
+++ b/pkg/proxy/proxy_http_test.go
@@ -1,0 +1,213 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/schubergphilis/mercury/pkg/healthcheck"
+	"github.com/stretchr/testify/assert"
+)
+
+const certPEM = "MIIHQDCCBiigAwIBAgIQD9B43Ujxor1NDyupa2A4/jANBgkqhkiG9w0BAQsFADBNMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMScwJQYDVQQDEx5EaWdpQ2VydCBTSEEyIFNlY3VyZSBTZXJ2ZXIgQ0EwHhcNMTgxMTI4MDAwMDAwWhcNMjAxMjAyMTIwMDAwWjCBpTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFDASBgNVBAcTC0xvcyBBbmdlbGVzMTwwOgYDVQQKEzNJbnRlcm5ldCBDb3Jwb3JhdGlvbiBmb3IgQXNzaWduZWQgTmFtZXMgYW5kIE51bWJlcnMxEzARBgNVBAsTClRlY2hub2xvZ3kxGDAWBgNVBAMTD3d3dy5leGFtcGxlLm9yZzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANDwEnSgliByCGUZElpdStA6jGaPoCkrp9vVrAzPpXGSFUIVsAeSdjF11yeOTVBqddF7U14nqu3rpGA68o5FGGtFM1yFEaogEv5grJ1MRY/d0w4+dw8JwoVlNMci+3QTuUKf9yH28JxEdG3J37Mfj2C3cREGkGNBnY80eyRJRqzy8I0LSPTTkhr3okXuzOXXg38ugr1x3SgZWDNuEaE6oGpyYJIBWZ9jF3pJQnucP9vTBejMh374qvyd0QVQq3WxHrogy4nUbWw3gihMxT98wRD1oKVma1NTydvthcNtBfhkp8kO64/hxLHrLWgOFT/l4tz8IWQt7mkrBHjbd2XLVPkCAwEAAaOCA8EwggO9MB8GA1UdIwQYMBaAFA+AYRyCMWHVLyjnjUY4tCzhxtniMB0GA1UdDgQWBBRmmGIC4AmRp9njNvt2xrC/oW2nvjCBgQYDVR0RBHoweIIPd3d3LmV4YW1wbGUub3JnggtleGFtcGxlLmNvbYILZXhhbXBsZS5lZHWCC2V4YW1wbGUubmV0ggtleGFtcGxlLm9yZ4IPd3d3LmV4YW1wbGUuY29tgg93d3cuZXhhbXBsZS5lZHWCD3d3dy5leGFtcGxlLm5ldDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMGsGA1UdHwRkMGIwL6AtoCuGKWh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9zc2NhLXNoYTItZzYuY3JsMC+gLaArhilodHRwOi8vY3JsNC5kaWdpY2VydC5jb20vc3NjYS1zaGEyLWc2LmNybDBMBgNVHSAERTBDMDcGCWCGSAGG/WwBATAqMCgGCCsGAQUFBwIBFhxodHRwczovL3d3dy5kaWdpY2VydC5jb20vQ1BTMAgGBmeBDAECAjB8BggrBgEFBQcBAQRwMG4wJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBGBggrBgEFBQcwAoY6aHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0U0hBMlNlY3VyZVNlcnZlckNBLmNydDAMBgNVHRMBAf8EAjAAMIIBfwYKKwYBBAHWeQIEAgSCAW8EggFrAWkAdwCkuQmQtBhYFIe7E6LMZ3AKPDWYBPkb37jjd80OyA3cEAAAAWdcMZVGAAAEAwBIMEYCIQCEZIG3IR36Gkj1dq5L6EaGVycXsHvpO7dKV0JsooTEbAIhALuTtf4wxGTkFkx8blhTV+7sf6pFT78ORo7+cP39jkJCAHYAh3W/51l8+IxDmV+9827/Vo1HVjb/SrVgwbTq/16ggw8AAAFnXDGWFQAABAMARzBFAiBvqnfSHKeUwGMtLrOG3UGLQIoaL3+uZsGTX3MfSJNQEQIhANL5nUiGBR6gl0QlCzzqzvorGXyB/yd7nttYttzo8EpOAHYAb1N2rDHwMRnYmQCkURX/dxUcEdkCwQApBo2yCJo32RMAAAFnXDGWnAAABAMARzBFAiEA5Hn7Q4SOyqHkT+kDsHq7ku7zRDuM7P4UDX2ft2Mpny0CIE13WtxJAUr0aASFYZ/XjSAMMfrB0/RxClvWVss9LHKMMA0GCSqGSIb3DQEBCwUAA4IBAQBzcIXvQEGnakPVeJx7VUjmvGuZhrr7DQOLeP4R8CmgDM1pFAvGBHiyzvCH1QGdxFl6cf7wbp7BoLCRLR/qPVXFMwUMzcE1GLBqaGZMv1Yh2lvZSLmMNSGRXdx113pGLCInpm/TOhfrvr0TxRImc8BdozWJavsn1N2qdHQuN+UBO6bQMLCD0KHEdSGFsuX6ZwAworxTg02/1qiDu7zW7RyzHvFYA4IAjpzvkPIaX6KjBtpdvp/aXabmL95YgBjT8WJ7pqOfrqhpcmOBZa6Cg6O1l4qbIFH/Gj9hQB5I0Gs4+eH6F9h3SojmPTYkT+8KuZ9w84Mn+M8qBXUQoYoKgIjN"
+
+var cert = mustParsePEMCertificate(certPEM)
+
+func TestProcessACLVariables(t *testing.T) {
+	//logging.Configure("stdout", "warning")
+
+	acl := []ACL{
+		ACL{
+			Action:      "add",
+			HeaderKey:   "key-a",
+			HeaderValue: "###CLIENT_IP###",
+		},
+		ACL{
+			Action:      "add",
+			CookieKey:   "key-a",
+			CookieValue: "###CLIENT_IP###",
+		},
+		ACL{
+			Action:      "add",
+			CookieKey:   "key-a",
+			CookieValue: "###UNKNOWN###",
+		},
+	}
+
+	listener := New("listener-id", "Listener", 999)
+	backendNode := BackendNode{}
+	request := createHTTPRequest()
+
+	newACL := processACLVariables(acl, listener, backendNode, request)
+	assert.Equal(t, "192.0.2.1", newACL[0].HeaderValue)
+	assert.Equal(t, "192.0.2.1", newACL[1].CookieValue)
+	assert.Equal(t, "UNKNOWN", newACL[2].CookieValue)
+}
+
+func TestGetVariableValue(t *testing.T) {
+	listener := New("listener-id", "Listener", 999)
+	listener.IP = "192.168.0.2"
+	listener.Port = 8080
+
+	backendNode := NewBackendNode("backend-id", "192.168.1.1", "server1", 22, 10, []string{}, 0, healthcheck.Online)
+
+	httpRequest := createHTTPRequest()
+	httpsRequest := createHTTPSRequest()
+	httpsRequestWithCertificate := createHTTPSRequestWithClientCertificate()
+
+	var testData = []struct {
+		name          string
+		expectedValue string
+		expectedError error
+		request       *http.Request
+	}{
+		{
+			name:          "UNKNOWN",
+			expectedValue: "",
+			expectedError: errors.New("Unknown variable: UNKNOWN"),
+			request:       httpRequest,
+		},
+		{
+			name:          "NODE_ID",
+			expectedValue: "backend-id",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "NODE_IP",
+			expectedValue: "192.168.1.1",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "LB_IP",
+			expectedValue: "192.168.0.2",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "LB_PORT",
+			expectedValue: "8080",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "REQ_URL",
+			expectedValue: "example.com:8080/foo",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "REQ_QUERY",
+			expectedValue: "key-a=value-a&key-b",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "REQ_PATH",
+			expectedValue: "/foo",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "REQ_HOST",
+			expectedValue: "example.com",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "REQ_IP",
+			expectedValue: "example.com",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "REQ_IP",
+			expectedValue: "127.0.0.1",
+			expectedError: nil,
+			request:       httptest.NewRequest("GET", "http://127.0.0.1:4443/", nil),
+		},
+		{
+			name:          "REQ_PROTO",
+			expectedValue: "http",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "REQ_PROTO",
+			expectedValue: "https",
+			expectedError: nil,
+			request:       httpsRequest,
+		},
+		{
+			name:          "CLIENT_IP",
+			expectedValue: "192.0.2.1",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "CLIENT_CERT",
+			expectedValue: "",
+			expectedError: nil,
+			request:       httpRequest,
+		},
+		{
+			name:          "CLIENT_CERT",
+			expectedValue: "",
+			expectedError: nil,
+			request:       httpsRequest,
+		},
+		{
+			name:          "CLIENT_CERT",
+			expectedValue: certPEM,
+			expectedError: nil,
+			request:       httpsRequestWithCertificate,
+		},
+	}
+
+	for index, data := range testData {
+		description := fmt.Sprintf("%v %v", index, data.name)
+		t.Run(description, func(t *testing.T) {
+			value, err := getVariableValue(data.name, listener, backendNode, data.request)
+			assert.Equal(t, data.expectedValue, value)
+			assert.Equal(t, data.expectedError, err)
+		})
+	}
+}
+
+func mustParsePEMCertificate(pemContent string) *x509.Certificate {
+	block, _ := pem.Decode([]byte("-----BEGIN CERTIFICATE-----\n" + pemContent + "\n-----END CERTIFICATE-----"))
+	if block == nil || block.Bytes == nil {
+		panic("Failed to parse PEM content")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return cert
+}
+
+func createHTTPRequest() *http.Request {
+	return httptest.NewRequest("GET", "http://example.com:8080/foo?key-a=value-a&key-b", nil)
+}
+
+func createHTTPSRequest() *http.Request {
+	req := httptest.NewRequest("GET", "https://example.com:4443/foo?key-a=value-a&key-b", nil)
+	req.TLS = &tls.ConnectionState{}
+	return req
+}
+
+func createHTTPSRequestWithClientCertificate() *http.Request {
+	req := createHTTPSRequest()
+	req.TLS.PeerCertificates = []*x509.Certificate{
+		mustParsePEMCertificate(certPEM),
+	}
+	return req
+}

--- a/pkg/proxy/proxy_http_test.go
+++ b/pkg/proxy/proxy_http_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/schubergphilis/mercury/pkg/healthcheck"
+	"github.com/schubergphilis/mercury/pkg/logging"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +20,7 @@ const certPEM = "MIIHQDCCBiigAwIBAgIQD9B43Ujxor1NDyupa2A4/jANBgkqhkiG9w0BAQsFADB
 var cert = mustParsePEMCertificate(certPEM)
 
 func TestProcessACLVariables(t *testing.T) {
-	//logging.Configure("stdout", "warning")
+	logging.Configure("stdout", "error")
 
 	acl := []ACL{
 		ACL{

--- a/pkg/proxy/proxy_listener.go
+++ b/pkg/proxy/proxy_listener.go
@@ -110,9 +110,6 @@ func (l *Listener) Start() {
 	case "https":
 		proxy := l.NewHTTPProxy()
 
-		// Receive client certificate if provided
-		l.TLSConfig.ClientAuth = tls.RequestClientCert
-
 		l.TLSConfig.GetClientCertificate = func(t *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			log.Debugf("Client requestinfo: %+v", t)
 			return nil, nil

--- a/pkg/proxy/proxy_listener.go
+++ b/pkg/proxy/proxy_listener.go
@@ -109,6 +109,10 @@ func (l *Listener) Start() {
 
 	case "https":
 		proxy := l.NewHTTPProxy()
+
+		// Receive client certificate if provided
+		l.TLSConfig.ClientAuth = tls.RequestClientCert
+
 		l.TLSConfig.GetClientCertificate = func(t *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			log.Debugf("Client requestinfo: %+v", t)
 			return nil, nil

--- a/pkg/tlsconfig/tls.go
+++ b/pkg/tlsconfig/tls.go
@@ -58,6 +58,15 @@ var TLSCipherLookup = map[string]uint16{
 	`tls_fallback_scsv`:                       tls.TLS_FALLBACK_SCSV,
 }
 
+// TLSClientAuthLookup is a lookup table for TLS Client Auth
+var TLSClientAuthLookup = map[string]tls.ClientAuthType{
+	`noclientcert`:               tls.NoClientCert,
+	`requestclientcert`:          tls.RequestClientCert,
+	`requireanyclientcert`:       tls.RequireAnyClientCert,
+	`verifyclientcertifgiven`:    tls.VerifyClientCertIfGiven,
+	`requireandverifyclientcert`: tls.RequireAndVerifyClientCert,
+}
+
 // TLSConfig is user definable config for TLS
 type TLSConfig struct {
 	CertificateKey     string   `json:"certificatekey" toml:"certificatekey"`
@@ -68,6 +77,7 @@ type TLSConfig struct {
 	CipherSuites       []string `json:"ciphersuites" toml:"ciphersuites"`
 	CurvePreferences   []string `json:"curvepreferences" toml:"curvepreferences"`
 	InsecureSkipVerify bool     `json:"insecureskipverify" toml:"insecureskipverify"`
+	ClientAuth         string   `json:"clientauth" toml:"clientauth"`
 }
 
 // LoadCertificate loads the user definable config and returns the tls.Config
@@ -119,6 +129,14 @@ func LoadCertificate(t TLSConfig) (c *tls.Config, err error) {
 			return c, err
 		}
 		c.Certificates = []tls.Certificate{cert}
+	}
+
+	if t.ClientAuth != "" {
+		clientAuth, ok := TLSClientAuthLookup[strings.ToLower(t.ClientAuth)]
+		if !ok {
+			return c, fmt.Errorf("Unknown TLSClientAuth: %s", t.ClientAuth)
+		}
+		c.ClientAuth = clientAuth
 	}
 
 	return c, nil

--- a/pkg/tlsconfig/tls_test.go
+++ b/pkg/tlsconfig/tls_test.go
@@ -13,6 +13,7 @@ func TestTLSConfig(t *testing.T) {
 		CurvePreferences: []string{"CurveP256"},
 		CertificateKey:   "../../test/ssl/self_signed_certificate.key",
 		CertificateFile:  "../../test/ssl/self_signed_certificate.crt",
+		ClientAuth:       "NoClientCert",
 	}
 	c, err := LoadCertificate(config)
 	if err != nil {
@@ -52,6 +53,13 @@ func TestTLSConfig(t *testing.T) {
 	_, err = LoadCertificate(fail)
 	if err == nil {
 		t.Errorf("Expected File load error")
+	}
+
+	fail = config
+	fail.ClientAuth = "Invalid"
+	_, err = LoadCertificate(fail)
+	if err == nil {
+		t.Errorf("Expected TLS Parsing error for ClientAuth")
 	}
 
 	err = AddCertificate(config, c)


### PR DESCRIPTION
@rdoorn 

I'm creating this PR because I need a way to forward client certificates through mercury.

Changes:
- Added CLIENT_CERT variable with certificate as base64 encoded PEM.
That can be used to create **x-forwarded-client-cert** header.
That's the same approach taken by Azure and Traefik:
https://docs.microsoft.com/bs-cyrl-ba/azure/app-service/app-service-web-configure-tls-mutual-auth?toc=%2Fazure%2Fapp-service-mobile%2Ftoc.json
Traefik
- Added LB_PORT variable with listener's port.
That can be used to create **x-forwarded-port** header.
- Added REQ_PROTO variable with values http or https.
That can be used to create **x-forwarded-proto** header.
- Changed behavior of REQ_IP to return first part of host. It was returning the port.
- Added tests for variable replacement in ACLs

I'm not a golang expert. Let me know what do you think.
