### PR TITLE
add fixes for go 1.5

### DIFF
--- a/pkg/cluster/api_test.go
+++ b/pkg/cluster/api_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -42,8 +43,11 @@ func TestApi(t *testing.T) {
 		t.Run("ClusterPublic", testAPIClusterPublic)
 		t.Run("ClusterAdmin", testAPIClusterAdmin)
 	})
+	// create a 10 second context for shutdown, whichever comes first
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-	if err := srv.Shutdown(nil); err != nil {
+	if err := srv.Shutdown(ctx); err != nil {
 		panic(err) // failure/timeout shutting down the server gracefully
 	}
 }

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -8,13 +8,13 @@ import (
 func TestDataParsing(t *testing.T) {
 
 	checks := map[string]string{
-		"###aewf###": "###aewf###",
-		"aewf":       "aewf",
+		"###aewf###":                                "###aewf###",
+		"aewf":                                      "aewf",
 		"###DATE+10m2006-01-02T15:04:05###.000Z":    "2012-12-12T12:22:12.000Z",
 		"###DATE-2h2006-01-02T15:04:05###":          "2012-12-12T10:12:12",
 		"###DATE-2h2006-01-02T15:04:05|UTC###":      "2012-12-12T08:12:12",
 		"###DATE-2h2006-01-02T15:04:05.000Z|UTC###": "2012-12-12T08:12:12.000Z",
-		"###DATE-9qhello###":                        "date parse error:time: unknown unit q in duration 9q",
+		"###DATE-9qhello###":                        "date parse error:time: unknown unit \"q\" in duration \"9q\"",
 	}
 
 	// Set static time to test functions

--- a/pkg/proxy/proxy_listener.go
+++ b/pkg/proxy/proxy_listener.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -182,7 +183,10 @@ func (l *Listener) Start() {
 
 			case HTTPS:
 				log.Debug("Stopping HTTP(s) Proxy on request")
-				err := httpsrv.Shutdown(nil)
+				// create a 10 second context for shutdown, whichever comes first
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				err := httpsrv.Shutdown(ctx)
 				if err != http.ErrServerClosed {
 					log.Debugf("Gracefull stop of Proxy failed: %s", err)
 					listener.Close()


### PR DESCRIPTION
we nore required a context on shutdown, and a string change in the error checking